### PR TITLE
Allow Mac OS X to link with SDL.

### DIFF
--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -14,8 +14,12 @@
 
 #elif defined(MACOSX)
 #include "ArchHooks/ArchHooks_MacOSX.h"
-#include "LoadingWindow/LoadingWindow_MacOSX.h"
+#if defined(HAVE_SDL)
+#include "LowLevelWindow/LowLevelWindow_SDL.h"
+#else
 #include "LowLevelWindow/LowLevelWindow_MacOSX.h"
+#endif
+#include "LoadingWindow/LoadingWindow_MacOSX.h"
 #include "MemoryCard/MemoryCardDriverThreaded_MacOSX.h"
 #define DEFAULT_INPUT_DRIVER_LIST "HID"
 #define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,Null"


### PR DESCRIPTION
Note that Mac OS X support is very experimental. It works...kind of. More work is necessary for full compliance, but it should not stop the PR from being merged in.
