### PR TITLE
Allow Windows to compile and link with SDL.

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -191,7 +191,14 @@ list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
   "arch/LowLevelWindow/LowLevelWindow.h"
 )
 
-if(WIN32)
+if(SDL2_FOUND)
+  list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
+    "arch/LowLevelWindow/LowLevelWindow_SDL.cpp"
+  )
+  list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
+    "arch/LowLevelWindow/LowLevelWindow_SDL.h"
+  )
+elseif(WIN32)
   list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
     "arch/LowLevelWindow/LowLevelWindow_Win32.cpp"
   )
@@ -199,38 +206,20 @@ if(WIN32)
     "arch/LowLevelWindow/LowLevelWindow_Win32.h"
   )
 elseif(APPLE)
-  if (SDL2_FOUND)
-    list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_SDL.cpp"
-    )
-    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
-      "arch/LowLevelWindow/LowLevelWindow_SDL.h"
-    )
-  else()
-    list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_MacOSX.mm"
-    )
-    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
-      "arch/LowLevelWindow/LowLevelWindow_MacOSX.h"
-    )
-  endif()
-else(UNIX)
-  if (SDL2_FOUND)
-    list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_SDL.cpp"      
-    )
-    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
-      "arch/LowLevelWindow/LowLevelWindow_SDL.h"
-    )
-  elseif (X11_FOUND)
-      list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
-      "arch/LowLevelWindow/LowLevelWindow_X11.cpp"   
-    )
-    list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
-      "arch/LowLevelWindow/LowLevelWindow_X11.h"
-    )
-  endif()
-endif(WIN32)
+  list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
+    "arch/LowLevelWindow/LowLevelWindow_MacOSX.mm"
+  )
+  list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
+    "arch/LowLevelWindow/LowLevelWindow_MacOSX.h"
+  )
+elseif (X11_FOUND)
+  list(APPEND SMDATA_ARCH_LOWLEVEL_SRC
+    "arch/LowLevelWindow/LowLevelWindow_X11.cpp"   
+  )
+  list(APPEND SMDATA_ARCH_LOWLEVEL_HPP
+    "arch/LowLevelWindow/LowLevelWindow_X11.h"
+  )
+endif()
 
 source_group("Arch Specific\\\\Low Level Window" FILES ${SMDATA_ARCH_LOWLEVEL_SRC} ${SMDATA_ARCH_LOWLEVEL_HPP})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,12 +183,25 @@ if(WIN32)
   )
 
   if(MSVC)
-    # Allow for getting a virtualdub stack trace.
-    add_custom_command(TARGET "${SM_EXE_NAME}"
-      POST_BUILD
-      COMMAND "mapconv" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.map" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.vdi"
-      COMMENT "Generating file to allow for easier stack traces."
+    # TODO: Look into a better way for custom commands to reduce duplication.
+    if (SDL2_FOUND)
+      get_filename_component(SDL2_DLL_DIR ${SDL2_LIBRARY} DIRECTORY)
+      add_custom_command(TARGET "${SM_EXE_NAME}"
+        POST_BUILD
+        # Attempt to allow generating a stack trace.
+        COMMAND "mapconv" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.map" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.vdi"
+        # Copy the SDL2.dll
+        COMMAND ${CMAKE_COMMAND} -E copy "${SDL2_DLL_DIR}/SDL2.dll" "${SM_PROGRAM_DIR}/SDL2.dll"
+        COMMENT "Post-build stuff for Windows."
     )
+    else()
+      # Allow for getting a virtualdub stack trace.
+      add_custom_command(TARGET "${SM_EXE_NAME}"
+        POST_BUILD
+        COMMAND "mapconv" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.map" "${SM_PROGRAM_DIR}/$<$<CONFIG:DEBUG>:${SM_NAME_DEBUG}>$<$<CONFIG:MINSIZEREL>:${SM_NAME_MINSIZEREL}>$<$<CONFIG:RELWITHDEBINFO>:${SM_NAME_RELWITHDEBINFO}>$<$<CONFIG:RELEASE>:${SM_NAME_RELEASE}>.vdi"
+        COMMENT "Generating file to allow for easier stack traces."
+      )
+    endif()
   endif()
 elseif(APPLE)
   set_target_properties("${SM_EXE_NAME}" PROPERTIES
@@ -389,6 +402,11 @@ if (WIN32)
     )
   endif()
 
+  if(SDL2_FOUND)
+    list(APPEND SMDATA_LINK_LIB ${SDL2_LIBRARY})
+    sm_add_compile_definition("${SM_EXE_NAME}" HAVE_SDL)
+  endif()
+
   list(APPEND SMDATA_LINK_LIB
     "dbghelp.lib"
     "setupapi.lib"
@@ -397,6 +415,9 @@ if (WIN32)
 
   get_filename_component(DIRECTX_LIBRARY_DIR "${DIRECTX_LIBRARIES}" DIRECTORY)
 
+  if (SDL2_FOUND)
+    sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${SDL2_LIBRARY}\"")
+  endif()
   sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${DIRECTX_LIBRARY_DIR}\"")
   sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${SM_EXTERN_DIR}/ffmpeg/lib\"")
   sm_add_link_flag("${SM_EXE_NAME}" "/LIBPATH:\"${SM_SRC_DIR}/archutils/Win32/ddk\"")

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -5,7 +5,11 @@
 #if defined(WINDOWS)
 #include "ArchHooks/ArchHooks_Win32.h"
 #include "LoadingWindow/LoadingWindow_Win32.h"
+#if defined(HAVE_SDL)
+#include "LowLevelWindow/LowLevelWindow_SDL.h"
+#else
 #include "LowLevelWindow/LowLevelWindow_Win32.h"
+#endif
 #include "MemoryCard/MemoryCardDriverThreaded_Windows.h"
 #define DEFAULT_INPUT_DRIVER_LIST "DirectInput,Pump,Para"
 #define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,DShow,Null"


### PR DESCRIPTION
This requires testing by other users. I did not get the expected results compared to Mac OS X.
- In the Graphics/Sounds options menu, I did not see any special display. It was just Fullscreen and Windowed in that order.
- Having the OpenGL renderer chosen instead of D3D caused a crash at the start.
- I had to manually set some cmake variables to get it to build. See the directions on `CMake/Modules/FindSDL2.cmake`. It may be better to find a way to pre-load some of those variables.
